### PR TITLE
Fix CLI install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ PM> Install-Package Mdameer.AspNetCore.CustomHeaders
 Or using the `dotnet` CLI
 
 ```bash
-dotnet package add Install-Package Mdameer.AspNetCore.CustomHeaders
+dotnet add package Mdameer.AspNetCore.CustomHeaders
 ```


### PR DESCRIPTION
## Summary
- fix the dotnet CLI command in README

## Testing
- `DOTNET_ROLL_FORWARD=Major dotnet test Mdameer.AspNetCore.CustomHeaders.sln`

------
https://chatgpt.com/codex/tasks/task_e_688c968e32988326bdaf470da72a1e4c